### PR TITLE
Fixed a bug in the UndirectedBlockmodel plain writer, TYPES should not include vertex numbers.

### DIFF
--- a/src/lib/io.cpp
+++ b/src/lib/io.cpp
@@ -245,7 +245,7 @@ void PlainTextWriter<UndirectedBlockmodel>::write(
 
     os << "TYPES\n";
     for (int i = 0; i < n; i++)
-        os << i << '\t' << model.getType(i) << '\n';
+        os << model.getType(i) << '\n';
     os << '\n';
 
     os << "PROBABILITIES\n";


### PR DESCRIPTION
As above.
